### PR TITLE
Allow replacements related to the power status

### DIFF
--- a/index.js
+++ b/index.js
@@ -656,7 +656,7 @@ HTTP_LIGHTBULB.prototype = {
 
                     callback();
                 }
-            });
+            }, ...this._collectCurrentValuesForReplacer());
         } else {
             this.mqttClient.publish(this.power.setTopic, on, error => {
                 if (error) {

--- a/index.js
+++ b/index.js
@@ -977,6 +977,9 @@ HTTP_LIGHTBULB.prototype = {
     _collectCurrentValuesForReplacer: function() {
         const args = [];
 
+        let on = this.homebridgeService.getCharacteristic(Characteristic.On).value;
+        args.push({searchValue: '"%on"', replacer: on ? 1 : 0});
+
         if (this.brightness) {
             let brightness = this.homebridgeService.getCharacteristic(Characteristic.Brightness).value;
             if (this.brightness.unit === BrightnessUnit.RGB)


### PR DESCRIPTION
Also triggered by my usage of the Elgato Key Light, I wanted to add some more flexibility around using e.g. brightness and color temp. replacement values in the `onUrl` and `offUrl` bodies and allow to use the current power state as a replacement when setting any of these other config values.

This is necessary because the Key Light always requires all the values to be sent in the `PUT` request's body, otherwise they are reset:
```json
{ 
  "numberOfLights":1,
  "lights": [{
    "on":1,
    "brightness":39,
    "temperature":159
  }]
}