### PR TITLE
Added support for lightbulbs that require color temperature updates via percent

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,11 @@ The configuration can contain the following properties:
         are available:
         * **"mired"**: Using mired (more specifically _microreciprocal degree_) to calculate color temperature
         * **"kelvin"**: Using Kelvin to calculate color temperature
+        * **"percent"**: Using percent to calculate color temperature
     * `minValue` \<number\> **optional** \(Default: **50**\): Defines the minimum supported temperature in the 
-        given `unit`. The defaut is **50** mired or **20.000** Kelvin.
+        given `unit`. The defaut is **50** mired or **20.000** Kelvin or **100** percent
     * `maxValue` \<number\> **optional** \(Default: **400**\): Defines the maximum supported temperature in the 
-        given `unit`. The fault is **400** mired or **2.500** Kelvin.
+        given `unit`. The fault is **400** mired or **2.500** Kelvin or **0** percent
     * `statusPattern` \<string\> **optional** \(Default: **"([0-9]{2,3})"** \[**"([0-9]{4,5})"** when using Kelvin\]): Defines a regex pattern with which the 
         color temperature is extracted from the body of the http response from the `colorTemperature.statusUrl`. 
         The group which should be extracted can be configured with the `colorTemperature.patternGroupToExtract` property.

--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ The configuration can contain the following properties:
         * **"kelvin"**: Using Kelvin to calculate color temperature
         * **"percent"**: Using percent to calculate color temperature
     * `minValue` \<number\> **optional** \(Default: **50**\): Defines the minimum supported temperature in the 
-        given `unit`. The defaut is **50** mired or **20.000** Kelvin or **100** percent.
+        given `unit`. The default is **50** mired or **20.000** Kelvin. If unit is defined as percent, `minValue` must be defined in mired. 100% maps to `minValue` (**50** mired by default).
     * `maxValue` \<number\> **optional** \(Default: **400**\): Defines the maximum supported temperature in the 
-        given `unit`. The fault is **400** mired or **2.500** Kelvin or **0** percent.
+        given `unit`. The default is **400** mired or **2.500** Kelvin. If unit is defined as percent, `minValue` must be defined in mired. 0% maps to `maxValue` (**400** mired by default).
     * `statusPattern` \<string\> **optional** \(Default: **"([0-9]{2,3})"** \[**"([0-9]{4,5})"** when using Kelvin\]): Defines a regex pattern with which the 
         color temperature is extracted from the body of the http response from the `colorTemperature.statusUrl`. 
         The group which should be extracted can be configured with the `colorTemperature.patternGroupToExtract` property.

--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ The configuration can contain the following properties:
         * **"kelvin"**: Using Kelvin to calculate color temperature
         * **"percent"**: Using percent to calculate color temperature
     * `minValue` \<number\> **optional** \(Default: **50**\): Defines the minimum supported temperature in the 
-        given `unit`. The defaut is **50** mired or **20.000** Kelvin or **100** percent
+        given `unit`. The defaut is **50** mired or **20.000** Kelvin or **100** percent.
     * `maxValue` \<number\> **optional** \(Default: **400**\): Defines the maximum supported temperature in the 
-        given `unit`. The fault is **400** mired or **2.500** Kelvin or **0** percent
+        given `unit`. The fault is **400** mired or **2.500** Kelvin or **0** percent.
     * `statusPattern` \<string\> **optional** \(Default: **"([0-9]{2,3})"** \[**"([0-9]{4,5})"** when using Kelvin\]): Defines a regex pattern with which the 
         color temperature is extracted from the body of the http response from the `colorTemperature.statusUrl`. 
         The group which should be extracted can be configured with the `colorTemperature.patternGroupToExtract` property.

--- a/index.js
+++ b/index.js
@@ -501,8 +501,10 @@ HTTP_LIGHTBULB.prototype = {
 
                         if (this.colorTemperature.unit === TemperatureUnit.KELVIN)
                             minValue = Math.floor(1000000 / minValue);
-                        if (this.colorTemperature.unit === TemperatureUnit.PERCENT)
-                            minValue = 0;
+
+                        else if (this.colorTemperature.unit === TemperatureUnit.PERCENT)
+                            minValue = minValue
+    
                         this.colorTemperature.minValue = minValue;
                     }
                     else
@@ -514,8 +516,10 @@ HTTP_LIGHTBULB.prototype = {
 
                         if (this.colorTemperature.unit === TemperatureUnit.KELVIN)
                             maxValue = Math.floor(1000000 / maxValue);
-                        if (this.colorTemperature.unit === TemperatureUnit.PERCENT)
-                            maxValue = 100;
+
+                        else if (this.colorTemperature.unit === TemperatureUnit.PERCENT)
+                            maxValue = maxValue
+                        
                         this.colorTemperature.maxValue = maxValue;
                     }
                     else
@@ -945,8 +949,8 @@ HTTP_LIGHTBULB.prototype = {
 
                 if (this.colorTemperature.unit === TemperatureUnit.KELVIN)
                     colorTemperature = Math.round(1000000 / colorTemperature); // converting Kelvin to mired
-                if (this.colorTemperature.unit === TemperatureUnit.PERCENT)
-                    colorTemperature = Math.round(400 - (3.5 * colorTemperature)); // converting percent to mired
+                else if (this.colorTemperature.unit === TemperatureUnit.PERCENT)
+                    colorTemperature = Math.round((0.01 * colorTemperature * (this.colorTemperature.minValue - this.colorTemperature.maxValue)) + this.colorTemperature.maxValue); // converting percent to mired
 
                 if (colorTemperature >= this.colorTemperature.minValue && colorTemperature <= this.colorTemperature.maxValue) {
                     if (this.debug)
@@ -967,8 +971,8 @@ HTTP_LIGHTBULB.prototype = {
         const colorTemperatureMired = colorTemperature;
         if (this.colorTemperature.unit === TemperatureUnit.KELVIN)
             colorTemperature = Math.round(1000000 / colorTemperature); // converting mired to Kelvin
-        if (this.colorTemperature.unit === TemperatureUnit.PERCENT)
-            colorTemperature = Math.round((-2/7) * (colorTemperature - 400)); // converting percent to mired
+        else if (this.colorTemperature.unit === TemperatureUnit.PERCENT)
+            colorTemperature = Math.round((100 * (colorTemperature - this.colorTemperature.maxValue)) / (this.colorTemperature.minValue - this.colorTemperature.maxValue)); // converting percent to mired
 
         http.httpRequest(this.colorTemperature.setUrl, (error, response, body) => {
             if (error) {
@@ -1022,8 +1026,8 @@ HTTP_LIGHTBULB.prototype = {
             let colorTemperature = this.homebridgeService.getCharacteristic(Characteristic.ColorTemperature).value;
             if (this.colorTemperature.unit === TemperatureUnit.KELVIN)
                 colorTemperature = Math.round(1000000 / colorTemperature);
-            if (this.colorTemperature.unit === TemperatureUnit.PERCENT)
-                colorTemperature = Math.round(400 - (3.5 * colorTemperature)); // converting percent to mired
+            else if (this.colorTemperature.unit === TemperatureUnit.PERCENT)
+                colorTemperature = Math.round((100 * (colorTemperature - this.colorTemperature.maxValue)) / (this.colorTemperature.minValue - this.colorTemperature.maxValue)); // converting percent to mired
 
             args.push({searchValue: "%colorTemperature", replacer: `${colorTemperature}`});
         }

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ const SaturationUnit = Object.freeze({
 const TemperatureUnit = Object.freeze({
     MICRORECIPROCAL_DEGREE: "mired",
     KELVIN: "kelvin",
+    PERCENT: "percent"
 });
 
 /*
@@ -500,6 +501,8 @@ HTTP_LIGHTBULB.prototype = {
 
                         if (this.colorTemperature.unit === TemperatureUnit.KELVIN)
                             minValue = Math.floor(1000000 / minValue);
+                        if (this.colorTemperature.unit === TemperatureUnit.PERCENT)
+                            minValue = 0;
                         this.colorTemperature.minValue = minValue;
                     }
                     else
@@ -511,6 +514,8 @@ HTTP_LIGHTBULB.prototype = {
 
                         if (this.colorTemperature.unit === TemperatureUnit.KELVIN)
                             maxValue = Math.floor(1000000 / maxValue);
+                        if (this.colorTemperature.unit === TemperatureUnit.PERCENT)
+                            maxValue = 100;
                         this.colorTemperature.maxValue = maxValue;
                     }
                     else
@@ -940,6 +945,8 @@ HTTP_LIGHTBULB.prototype = {
 
                 if (this.colorTemperature.unit === TemperatureUnit.KELVIN)
                     colorTemperature = Math.round(1000000 / colorTemperature); // converting Kelvin to mired
+                if (this.colorTemperature.unit === TemperatureUnit.PERCENT)
+                    colorTemperature = Math.round(400 - (3.5 * colorTemperature)); // converting percent to mired
 
                 if (colorTemperature >= this.colorTemperature.minValue && colorTemperature <= this.colorTemperature.maxValue) {
                     if (this.debug)
@@ -960,6 +967,8 @@ HTTP_LIGHTBULB.prototype = {
         const colorTemperatureMired = colorTemperature;
         if (this.colorTemperature.unit === TemperatureUnit.KELVIN)
             colorTemperature = Math.round(1000000 / colorTemperature); // converting mired to Kelvin
+        if (this.colorTemperature.unit === TemperatureUnit.PERCENT)
+            colorTemperature = Math.round((-2/7) * (colorTemperature - 400)); // converting percent to mired
 
         http.httpRequest(this.colorTemperature.setUrl, (error, response, body) => {
             if (error) {
@@ -1013,6 +1022,8 @@ HTTP_LIGHTBULB.prototype = {
             let colorTemperature = this.homebridgeService.getCharacteristic(Characteristic.ColorTemperature).value;
             if (this.colorTemperature.unit === TemperatureUnit.KELVIN)
                 colorTemperature = Math.round(1000000 / colorTemperature);
+            if (this.colorTemperature.unit === TemperatureUnit.PERCENT)
+                colorTemperature = Math.round(400 - (3.5 * colorTemperature)); // converting percent to mired
 
             args.push({searchValue: "%colorTemperature", replacer: `${colorTemperature}`});
         }


### PR DESCRIPTION
An example is the [VeSyncESL100CW](http://www.vesync.com/etekcity-smart-led-cool-to-warm-white-light-bulb-esl100cw). 

0% maps to 400 mired and 100% maps to 50 mired.

`mired = 400 - (3.5 * percent)`

```"unit":"percent"``` can be used as a key-value pair in ```config.json``` to use percentages to upgrade color temperature